### PR TITLE
fix: updating the AST to support spotify's openapi spec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,6 @@ mod tests {
         path,
     };
 
-    use crate::spec::{Components, ObjectOrReference};
     use pretty_assertions::assert_eq;
 
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@
 #![deny(rust_2018_idioms, nonstandard_style)]
 #![warn(missing_debug_implementations)]
 
-use serde::de::{Visitor, Deserializer, MapAccess};
-use std::{fs::File, io::Read, path::Path};
+use serde::de::{Deserializer, MapAccess, Visitor};
 use std::fmt;
+use std::{fs::File, io::Read, path::Path};
 
 mod error;
 pub mod spec;
@@ -65,9 +65,8 @@ pub fn to_json(spec: &OpenApiV3Spec) -> Result<String, Error> {
 
 pub fn deserialize_extensions<'de, D>(deserializer: D) -> Result<serde_yaml::Value, D::Error>
 where
-    D: Deserializer<'de>
+    D: Deserializer<'de>,
 {
-
     struct ExtraFieldsVisitor;
 
     impl<'de> Visitor<'de> for ExtraFieldsVisitor {
@@ -78,8 +77,8 @@ where
         }
 
         fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
-            where
-                M: MapAccess<'de>,
+        where
+            M: MapAccess<'de>,
         {
             let mut map = serde_yaml::Mapping::new();
             while let Some((key, value)) = access.next_entry()? {
@@ -101,8 +100,8 @@ mod tests {
         path,
     };
 
-    use pretty_assertions::assert_eq;
     use crate::spec::{Components, ObjectOrReference};
+    use pretty_assertions::assert_eq;
 
     use super::*;
 

--- a/src/spec/components.rs
+++ b/src/spec/components.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize};
 use crate::deserialize_extensions;
+use serde::{Deserialize, Serialize};
 
 use super::{
     schema::Schema, Callback, Example, Header, Link, ObjectOrReference, Parameter, PathItem,

--- a/src/spec/components.rs
+++ b/src/spec/components.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
+use crate::deserialize_extensions;
 
 use super::{
     schema::Schema, Callback, Example, Header, Link, ObjectOrReference, Parameter, PathItem,
@@ -64,5 +65,8 @@ pub struct Components {
     #[serde(default)]
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub callbacks: BTreeMap<String, ObjectOrReference<Callback>>,
-    // TODO: Add "Specification Extensions" https://github.com/OAI/OpenAPI-Specification/blob/HEAD/versions/3.1.0.md#specificationExtensions}
+
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_extensions")]
+    pub extensions: serde_yaml::Value,
 }

--- a/src/spec/parameter.rs
+++ b/src/spec/parameter.rs
@@ -63,6 +63,13 @@ pub struct Parameter {
     /// `header` - `simple`; for cookie - `form`.
     #[serde(skip_serializing_if = "Option::is_none")]
     style: Option<ParameterStyle>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    explode: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "in")]
+    param_in: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -70,6 +77,7 @@ pub struct Parameter {
 enum ParameterStyle {
     Form,
     Simple,
+    DeepObject,
 }
 
 impl FromRef for Parameter {

--- a/src/spec/schema.rs
+++ b/src/spec/schema.rs
@@ -1,11 +1,13 @@
 //! Schema specification for [OpenAPI 3.0.1](https://github.com/OAI/OpenAPI-Specification/blob/HEAD/versions/3.1.0.md)
 
 use std::collections::BTreeMap;
+use std::fmt::Write;
 
 use derive_more::{Display, Error};
 use serde::{Deserialize, Serialize};
 
 use crate::spec::{FromRef, ObjectOrReference, Ref, RefError, RefType, Spec};
+use crate::deserialize_extensions;
 
 /// Schema Errors
 #[derive(Debug, Clone, PartialEq, Display, Error)]
@@ -29,6 +31,12 @@ pub enum Type {
     String,
     Array,
     Object,
+}
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum ObjectOrFalse<T> {
+    False(bool),
+    Object(T),
 }
 
 // FIXME: Verify against OpenAPI 3.0
@@ -84,7 +92,7 @@ pub struct Schema {
     /// See <https://github.com/OAI/OpenAPI-Specification/blob/HEAD/versions/3.1.0.md#properties>.
     #[serde(rename = "additionalProperties")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_properties: Option<Box<ObjectOrReference<Schema>>>,
+    pub additional_properties: Option<Box<ObjectOrFalse<ObjectOrReference<Schema>>>>,
 
     //
     // additional metadata
@@ -104,7 +112,7 @@ pub struct Schema {
     #[serde(default)]
     #[serde(rename = "enum")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub enum_values: Vec<String>,
+    pub enum_values: Vec<serde_yaml::Value>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pattern: Option<String>,

--- a/src/spec/schema.rs
+++ b/src/spec/schema.rs
@@ -6,8 +6,8 @@ use std::fmt::Write;
 use derive_more::{Display, Error};
 use serde::{Deserialize, Serialize};
 
-use crate::spec::{FromRef, ObjectOrReference, Ref, RefError, RefType, Spec};
 use crate::deserialize_extensions;
+use crate::spec::{FromRef, ObjectOrReference, Ref, RefError, RefType, Spec};
 
 /// Schema Errors
 #[derive(Debug, Clone, PartialEq, Display, Error)]

--- a/src/spec/schema.rs
+++ b/src/spec/schema.rs
@@ -1,12 +1,10 @@
 //! Schema specification for [OpenAPI 3.0.1](https://github.com/OAI/OpenAPI-Specification/blob/HEAD/versions/3.1.0.md)
 
 use std::collections::BTreeMap;
-use std::fmt::Write;
 
 use derive_more::{Display, Error};
 use serde::{Deserialize, Serialize};
 
-use crate::deserialize_extensions;
 use crate::spec::{FromRef, ObjectOrReference, Ref, RefError, RefType, Spec};
 
 /// Schema Errors


### PR DESCRIPTION
The current AST fails when trying to parse the spotify spec present at this link https://raw.githubusercontent.com/tailcallhq/tailcall/openapi/src/core/generator/openapi/spotify.yml). This PR contains the changes for fixing it.