### PR TITLE
fix: allow parameters without .examples

### DIFF
--- a/src/spec/parameter.rs
+++ b/src/spec/parameter.rs
@@ -173,8 +173,8 @@ pub struct Parameter {
     /// encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if
     /// referencing a `schema` that contains an example, the `examples` value SHALL override the
     /// example provided by the schema.
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub examples: BTreeMap<String, ObjectOrReference<Example>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub examples: Option<BTreeMap<String, ObjectOrReference<Example>>>,
 
     /// A map containing the representations for the parameter.
     ///

--- a/tests/samples.rs
+++ b/tests/samples.rs
@@ -10,6 +10,7 @@ fn validate_passing_samples() {
     oas3::from_str(include_str!("samples/pass/path_no_response.yaml")).unwrap();
     oas3::from_str(include_str!("samples/pass/path_var_empty_pathitem.yaml")).unwrap();
     oas3::from_str(include_str!("samples/pass/schema.yaml")).unwrap();
+    oas3::from_str(include_str!("samples/pass/parameters.yaml")).unwrap();
 }
 
 #[test]

--- a/tests/samples/pass/parameters.yaml
+++ b/tests/samples/pass/parameters.yaml
@@ -1,0 +1,30 @@
+openapi: 3.1.0
+info:
+  summary: My API's summary
+  title: My API
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+jsonSchemaDialect: https://spec.openapis.org/oas/3.1/dialect/base
+paths:
+  /:
+    get:
+      parameters:
+        - $ref: "#/components/parameters/limitParam"
+        - name: foo
+          in: query
+          description: bar
+          required: false
+          schema:
+            type:
+components:
+  parameters:
+    limitParam:
+      name: limit
+      in: query
+      description: Limits the number of returned results
+      required: false
+      schema:
+        type: integer
+


### PR DESCRIPTION
Introduced in version `0.6` the field `examples` on `Parameter` is mandatory. When parsing a schema with a parameter that does not have examples you receive an error like that:

```
called `Result::unwrap()` on an `Err` value: Yaml(Error("paths./.get.parameters: data did not match any variant of untagged enum ObjectOrReference", line: 14, column: 9))
```

This PR adds a test and makes the field optional.
