### PR TITLE
feat: Adding support to parse discriminator field in ObjectSchema

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
         "refpath",
         "reqwest",
         "rustfmt",
+        "rustup",
         "semver",
         "serde",
         "spdx",

--- a/crates/oas3/CHANGELOG.md
+++ b/crates/oas3/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add `spec::ObjectSchema::deprecated` field.
 - Add `spec::ObjectSchema::examples` field.
 - Add `spec::Contact::validate_email()` method.
+- Add `spec::Discriminator` type.
+- Add `spec::ObjectSchema::discriminator` field.
 - Expose the `spec::ClientCredentialsFlow::token_url` field.
 - The type of the `spec::ObjectSchema::enum` field is now `Vec<serde_json::Value>`.
 - The type of the `spec::ObjectSchema::const` field is now `Option<serde_json::Value>`.

--- a/crates/oas3/src/spec/discriminator.rs
+++ b/crates/oas3/src/spec/discriminator.rs
@@ -1,0 +1,57 @@
+//! Schema specification for [OpenAPI 3.1](https://github.com/OAI/OpenAPI-Specification/blob/HEAD/versions/3.1.0.md)
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// The discriminator is a specific object in a schema which is used to inform the consumer of
+/// the document of an alternative schema based on the value associated with it.
+///
+/// See <https://spec.openapis.org/oas/v3.1.0#discriminator-object>
+#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
+pub struct Discriminator {
+    /// The name of the property in the payload that will hold the discriminator value.
+    #[serde(rename = "propertyName")]
+    pub property_name: String,
+
+    /// An object to hold mappings between payload values and schema names or references
+    ///
+    /// When using the discriminator, inline schemas will not be considered
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mapping: Option<BTreeMap<String, String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discriminator_property_name_parsed_correctly() {
+        let spec = "propertyName: testName";
+        let discriminator = serde_yml::from_str::<Discriminator>(spec).unwrap();
+        assert_eq!("testName", discriminator.property_name);
+        assert!(discriminator.mapping.is_none());
+    }
+
+    #[test]
+    fn discriminator_mapping_parsed_correctly() {
+        let spec = indoc::indoc! {"
+            propertyName: petType
+            mapping: 
+              dog: '#/components/schemas/Dog'
+              cat: '#/components/schemas/Cat'
+              monster: 'https://gigantic-server.com/schemas/Monster/schema.json'
+        "};
+        let discriminator = serde_yml::from_str::<Discriminator>(spec).unwrap();
+
+        assert_eq!("petType", discriminator.property_name);
+        let mapping = discriminator.mapping.unwrap();
+
+        assert_eq!("#/components/schemas/Dog", mapping.get("dog").unwrap());
+        assert_eq!("#/components/schemas/Cat", mapping.get("cat").unwrap());
+        assert_eq!(
+            "https://gigantic-server.com/schemas/Monster/schema.json",
+            mapping.get("monster").unwrap()
+        );
+    }
+}

--- a/crates/oas3/src/spec/discriminator.rs
+++ b/crates/oas3/src/spec/discriminator.rs
@@ -4,19 +4,19 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-/// The discriminator is a specific object in a schema which is used to inform the consumer of
-/// the document of an alternative schema based on the value associated with it.
+/// The discriminator is a specific object in a schema which is used to inform the consumer of the
+/// document of an alternative schema based on the value associated with it.
 ///
-/// See <https://spec.openapis.org/oas/v3.1.0#discriminator-object>
-#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
+/// See <https://spec.openapis.org/oas/v3.1.0#discriminator-object>.
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Discriminator {
-    /// The name of the property in the payload that will hold the discriminator value.
-    #[serde(rename = "propertyName")]
+    /// Name of the property in the payload that will hold the discriminator value.
     pub property_name: String,
 
-    /// An object to hold mappings between payload values and schema names or references
+    /// Object to hold mappings between payload values and schema names or references.
     ///
-    /// When using the discriminator, inline schemas will not be considered
+    /// When using the discriminator, inline schemas will not be considered.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mapping: Option<BTreeMap<String, String>>,
 }
@@ -37,7 +37,7 @@ mod tests {
     fn discriminator_mapping_parsed_correctly() {
         let spec = indoc::indoc! {"
             propertyName: petType
-            mapping: 
+            mapping:
               dog: '#/components/schemas/Dog'
               cat: '#/components/schemas/Cat'
               monster: 'https://gigantic-server.com/schemas/Monster/schema.json'

--- a/crates/oas3/src/spec/discriminator.rs
+++ b/crates/oas3/src/spec/discriminator.rs
@@ -4,10 +4,13 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+/// A discriminator object can be used to aid in serialization, deserialization, and validation when
+/// payloads may be one of a number of different schemas.
+///
 /// The discriminator is a specific object in a schema which is used to inform the consumer of the
 /// document of an alternative schema based on the value associated with it.
 ///
-/// See <https://spec.openapis.org/oas/v3.1.0#discriminator-object>.
+/// See <https://github.com/OAI/OpenAPI-Specification/blob/HEAD/versions/3.1.0.md#discriminator-object>.
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Discriminator {

--- a/crates/oas3/src/spec/mod.rs
+++ b/crates/oas3/src/spec/mod.rs
@@ -39,6 +39,7 @@ mod tag;
 pub use self::{
     components::*,
     contact::*,
+    discriminator::*,
     encoding::*,
     error::Error,
     example::*,

--- a/crates/oas3/src/spec/mod.rs
+++ b/crates/oas3/src/spec/mod.rs
@@ -13,6 +13,7 @@ mod components;
 mod contact;
 mod encoding;
 
+mod discriminator;
 mod error;
 mod example;
 mod external_doc;

--- a/crates/oas3/src/spec/schema.rs
+++ b/crates/oas3/src/spec/schema.rs
@@ -649,10 +649,12 @@ mod tests {
           discriminator:
             propertyName: petType
             mapping:
-            dog: '#/components/schemas/Dog'
-            monster: 'https://gigantic-server.com/schemas/Monster/schema.json'
+                dog: '#/components/schemas/Dog'
+                monster: 'https://gigantic-server.com/schemas/Monster/schema.json'
         "};
         let schema = serde_yml::from_str::<ObjectSchema>(spec).unwrap();
+
         assert!(schema.discriminator.is_some());
+        assert_eq!(2, schema.discriminator.unwrap().mapping.unwrap().len());
     }
 }

--- a/crates/oas3/src/spec/schema.rs
+++ b/crates/oas3/src/spec/schema.rs
@@ -530,6 +530,9 @@ pub struct ObjectSchema {
     #[serde(flatten, with = "spec_extensions")]
     pub extensions: BTreeMap<String, serde_json::Value>,
 
+    /// Discriminator for object selection based on propertyName
+    ///
+    /// See <https://spec.openapis.org/oas/v3.1.0#discriminator-object>
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub discriminator: Option<Discriminator>,
 }

--- a/crates/oas3/src/spec/schema.rs
+++ b/crates/oas3/src/spec/schema.rs
@@ -649,8 +649,8 @@ mod tests {
           discriminator:
             propertyName: petType
             mapping:
-                dog: '#/components/schemas/Dog'
-                monster: 'https://gigantic-server.com/schemas/Monster/schema.json'
+              dog: '#/components/schemas/Dog'
+              monster: 'https://gigantic-server.com/schemas/Monster/schema.json'
         "};
         let schema = serde_yml::from_str::<ObjectSchema>(spec).unwrap();
 

--- a/crates/oas3/src/spec/schema.rs
+++ b/crates/oas3/src/spec/schema.rs
@@ -501,6 +501,12 @@ pub struct ObjectSchema {
     // #########################################################################
 
     //
+    /// Discriminator for object selection based on propertyName
+    ///
+    /// See <https://github.com/OAI/OpenAPI-Specification/blob/HEAD/versions/3.1.0.md#discriminator-object>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discriminator: Option<Discriminator>,
+
     /// A free-form property to include an example of an instance for this schema.
     ///
     /// To represent examples that cannot be naturally represented in JSON or YAML, a string value
@@ -529,12 +535,6 @@ pub struct ObjectSchema {
     /// See <https://github.com/OAI/OpenAPI-Specification/blob/HEAD/versions/3.1.0.md#specification-extensions>.
     #[serde(flatten, with = "spec_extensions")]
     pub extensions: BTreeMap<String, serde_json::Value>,
-
-    /// Discriminator for object selection based on propertyName
-    ///
-    /// See <https://github.com/OAI/OpenAPI-Specification/blob/HEAD/versions/3.1.0.md#discriminator-object>
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub discriminator: Option<Discriminator>,
 }
 
 impl ObjectSchema {

--- a/crates/oas3/src/spec/schema.rs
+++ b/crates/oas3/src/spec/schema.rs
@@ -532,7 +532,7 @@ pub struct ObjectSchema {
 
     /// Discriminator for object selection based on propertyName
     ///
-    /// See <https://spec.openapis.org/oas/v3.1.0#discriminator-object>
+    /// See <https://github.com/OAI/OpenAPI-Specification/blob/HEAD/versions/3.1.0.md#discriminator-object>
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub discriminator: Option<Discriminator>,
 }

--- a/tests/samples.rs
+++ b/tests/samples.rs
@@ -15,7 +15,7 @@ fn validate_passing_samples() {
 #[test]
 fn validate_failing_samples() {
     // TODO: implement validation for one-of: [paths, components, webhooks]
-    // see https://spec.openapis.org/oas/v3.1.0#openapi-document
+    // see https://github.com/OAI/OpenAPI-Specification/blob/HEAD/versions/3.1.0.md#openapi-document
     // oas3::from_str(include_str!("samples/fail/no_containers.yaml")).unwrap_err();
 
     // TODO: implement validation for non-empty server enum


### PR DESCRIPTION
Closes #131
Specification https://spec.openapis.org/oas/v3.1.0#discriminator-object

Might be labeled as fix as well (e.g. fix discriminator field not parsed). 