### PR TITLE
Make serde_yaml dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ http = "1"
 indoc = "2"
 log = "0.4"
 maplit = "1"
-oas3 = "0.14"
+oas3 = { version = "0.14", default-features = false }
 once_cell = "1"
 pretty_assertions = "1"
 pretty_env_logger = "0.5"

--- a/crates/oas3/Cargo.toml
+++ b/crates/oas3/Cargo.toml
@@ -11,8 +11,9 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 
 [features]
-default = ["validation"]
+default = ["validation", "yaml_spec"]
 validation = []
+yaml_spec = ["dep:serde_yaml"]
 
 [dependencies]
 derive_more = { workspace = true, features = ["display", "error", "from"] }
@@ -23,13 +24,18 @@ regex = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
+serde_yaml = { workspace = true, optional = true }
 url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 eyre = { workspace = true }
 indoc = { workspace = true }
 pretty_assertions = { workspace = true }
+
+[[example]]
+name = "printers"
+path = "examples/printer.rs"
+required-features = ["yaml_spec"]
 
 [lints]
 workspace = true

--- a/crates/oas3/src/error.rs
+++ b/crates/oas3/src/error.rs
@@ -15,6 +15,7 @@ pub enum Error {
 
     /// YAML error.
     #[display("YAML error")]
+    #[cfg(feature = "yaml_spec")]
     Yaml(serde_yaml::Error),
 
     /// JSON error.

--- a/crates/oas3/src/spec/discriminator.rs
+++ b/crates/oas3/src/spec/discriminator.rs
@@ -24,7 +24,7 @@ pub struct Discriminator {
     pub mapping: Option<BTreeMap<String, String>>,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "yaml_spec"))]
 mod tests {
     use super::*;
 

--- a/crates/oas3/src/spec/media_type_examples.rs
+++ b/crates/oas3/src/spec/media_type_examples.rs
@@ -83,6 +83,7 @@ impl MediaTypeExamples {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "yaml_spec")]
     use serde_json::json;
 
     use super::*;
@@ -98,6 +99,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "yaml_spec")]
     fn deserialize() {
         assert_eq!(
             serde_yaml::from_str::<MediaTypeExamples>(indoc::indoc! {"
@@ -119,6 +121,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "yaml_spec")]
     fn serialize() {
         let mt_examples = MediaTypeExamples::default();
         assert_eq!(
@@ -140,6 +143,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "yaml_spec")]
     fn single_example() {
         let spec = serde_yaml::from_str::<Spec>(indoc::indoc! {"
 openapi: 3.1.0
@@ -167,6 +171,7 @@ paths: {}
     }
 
     #[test]
+    #[cfg(feature = "yaml_spec")]
     fn resolve_references() {
         let spec = serde_yaml::from_str::<Spec>(indoc::indoc! {"
 openapi: 3.1.0

--- a/crates/oas3/src/spec/mod.rs
+++ b/crates/oas3/src/spec/mod.rs
@@ -228,7 +228,7 @@ impl Spec {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "yaml_spec"))]
 mod tests {
     use pretty_assertions::assert_eq;
 

--- a/crates/oas3/src/spec/parameter.rs
+++ b/crates/oas3/src/spec/parameter.rs
@@ -223,7 +223,7 @@ impl FromRef for Parameter {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "yaml_spec"))]
 mod tests {
     use indoc::indoc;
 

--- a/crates/oas3/src/spec/schema.rs
+++ b/crates/oas3/src/spec/schema.rs
@@ -593,7 +593,7 @@ where
     T::deserialize(de).map(Some)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "yaml_spec"))]
 mod tests {
     use super::*;
 

--- a/crates/oas3/src/spec/spec_extensions.rs
+++ b/crates/oas3/src/spec/spec_extensions.rs
@@ -5,6 +5,11 @@ use std::{
 
 use serde::{de, Deserializer, Serializer};
 
+#[cfg(feature = "yaml_spec")]
+type KeyType = serde_yaml::Value;
+#[cfg(not(feature = "yaml_spec"))]
+type KeyType = serde_json::Value;
+
 /// Deserializes fields of a map beginning with `x-`.
 pub(crate) fn deserialize<'de, D>(
     deserializer: D,
@@ -25,7 +30,7 @@ where
         where
             M: de::MapAccess<'de>,
         {
-            let mut map = HashMap::<serde_yaml::Value, serde_json::Value>::new();
+            let mut map = HashMap::<KeyType, serde_json::Value>::new();
 
             while let Some((key, value)) = access.next_entry()? {
                 map.insert(key, value);

--- a/crates/roast/Cargo.toml
+++ b/crates/roast/Cargo.toml
@@ -17,7 +17,7 @@ derive_more = { workspace = true, features = ["display", "error", "from"] }
 futures-util = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-oas3 = { workspace = true }
+oas3 = { workspace = true, default-features = false }
 once_cell = { workspace = true }
 prettytable-rs = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }


### PR DESCRIPTION
Thanks for already removing the problematic `serde_yml` dependency. I just went a step further and added a feature to allow to remove any yaml dependencies for these that don't need to handle the yaml format.

Fixes #152