### PR TITLE
Drop default features for `reqwest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ pretty_assertions = "1"
 pretty_env_logger = "0.5"
 prettytable-rs = "0.10"
 regex = "1.11.1"
-reqwest = "0.12"
+reqwest = { version = "0.12", default-features = false }
 semver = "1"
 serde = "1"
 serde_json = "1"


### PR DESCRIPTION
This commit disables the default features for `reqwest`, this prevents accidently pulling in unwanted dependencies like `openssl` in downstream crates.