### PR TITLE
feat: implement FromRef for SecurityScheme

### DIFF
--- a/crates/oas3/CHANGELOG.md
+++ b/crates/oas3/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Document compatibility with OAS v3.1.1.
 - Remove non-spec-compliant `spec::Header::allow_empty_value` field.
 - Minimum supported Rust version (MSRV) is now 1.80.
+- Implement `FromRef` for `spec::SecurityScheme`
 
 ## 0.16.1
 


### PR DESCRIPTION
Howdy. I'm working on an app that needs to resolve security schemes to their referenced values, so I added a `FromRef` impl on `SecurityScheme`. I copied the impl for `Parameter` so it was pretty straightforward.