### PR TITLE
Do not `.unwrap()` on potentially `None` schema

### DIFF
--- a/crates/oas3/src/spec/media_type.rs
+++ b/crates/oas3/src/spec/media_type.rs
@@ -33,7 +33,7 @@ impl MediaType {
     pub fn schema(&self, spec: &Spec) -> Result<ObjectSchema, Error> {
         self.schema
             .as_ref()
-            .unwrap()
+            .ok_or(Error::Schema(super::SchemaError::NoSchema))?
             .resolve(spec)
             .map_err(Error::Ref)
     }

--- a/crates/oas3/src/spec/schema.rs
+++ b/crates/oas3/src/spec/schema.rs
@@ -24,6 +24,10 @@ pub enum Error {
     /// Required property list specified for a non-object schema.
     #[display("Required property list specified for a non-object schema")]
     RequiredSpecifiedOnNonObject,
+
+    /// `Option<ObjectOrReference<ObjectSchema>>` evaluated to be `None`.
+    #[display("Cannot attempt to resolve this schema because Option<ObjectOrReference<ObjectSchema>> evaluated to None")]
+    NoSchema,
 }
 
 /// Single schema type.


### PR DESCRIPTION
I have encountered a program-crashing error, where, when calling `.schema(&spec)` on a `MediaType`, the program will panic, if the `MediaType`'s inner `Option<ObjectOrReference<ObjectSchema>>>` is `None`. This should not happen, especially because the method in question already returns a `Result<T, E>` type, which allows for error handling at the callsite.

This PR simply substitutes the `unwrap()` call with an `ok_or()`-call, which yields a newly defined `SchemaError` variant "`NoSchema`", if the inner `Option<ObjectOrReference<ObjectSchema>>>` is `None`. 