### PR TITLE
Support boolean schemas in OpenAPI 3.1 properties and composition keywords

### DIFF
--- a/crates/oas3/CHANGELOG.md
+++ b/crates/oas3/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Support boolean schemas in `spec::ObjectSchema::{all_of, any_of, one_of, prefix_items, properties}`.
+- Add `spec::Schema::resolve()` method.
 - Migrate YAML parsing to `yaml_serde`. Exposed error type(s) have been altered.
 - Return `RefError::Unresolvable` for malformed `$ref` paths instead of panicking.
 - Minimum supported Rust version (MSRV) is now 1.81.

--- a/crates/oas3/src/spec/schema.rs
+++ b/crates/oas3/src/spec/schema.rs
@@ -793,4 +793,44 @@ mod tests {
 
         pretty_assertions::assert_eq!(spec, serialized);
     }
+
+    #[test]
+    fn properties_supports_boolean_schemas() {
+        // Test for issue #278 - boolean schemas in properties
+        let spec = indoc::indoc! {"
+          type: object
+          properties:
+            data: true
+            meta: false
+        "};
+        let schema = serde_yaml::from_str::<ObjectSchema>(spec).unwrap();
+
+        assert_eq!(
+            2,
+            schema.properties.len(),
+            "properties should have two elements",
+        );
+
+        // Check data property is true boolean schema
+        let data_schema = schema.properties.get("data").expect("data property should exist");
+        match data_schema {
+            ObjectOrReference::Object(obj) => {
+                panic!("Expected boolean schema, got object: {:?}", obj);
+            }
+            ObjectOrReference::Ref { .. } => {
+                panic!("Expected boolean schema, got reference");
+            }
+        }
+
+        // Check meta property is false boolean schema
+        let meta_schema = schema.properties.get("meta").expect("meta property should exist");
+        match meta_schema {
+            ObjectOrReference::Object(obj) => {
+                panic!("Expected boolean schema, got object: {:?}", obj);
+            }
+            ObjectOrReference::Ref { .. } => {
+                panic!("Expected boolean schema, got reference");
+            }
+        }
+    }
 }

--- a/crates/oas3/src/spec/schema.rs
+++ b/crates/oas3/src/spec/schema.rs
@@ -600,7 +600,13 @@ impl Schema {
     /// Resolves the schema (if needed) from the given `spec` and returns an `ObjectSchema`.
     ///
     /// For boolean schemas, this returns an empty `ObjectSchema` since boolean schemas
-    /// don't have a structure to resolve into.
+    /// don't have a traditional structure to resolve into. Note that this loses the boolean
+    /// validation semantics:
+    /// - `true` (accept all) becomes an empty schema with no constraints
+    /// - `false` (reject all) becomes an empty schema with no constraints
+    ///
+    /// Callers should check if the schema is a boolean schema and handle it specially
+    /// if boolean validation semantics need to be preserved.
     pub fn resolve(&self, spec: &Spec) -> Result<ObjectSchema, RefError> {
         match self {
             Schema::Boolean(_) => Ok(ObjectSchema::default()),


### PR DESCRIPTION
This pull request refactors the `ObjectSchema` struct to use the more general `Schema` type for several fields, allowing support for boolean schemas (`true`/`false`) in places like `properties`, `allOf`, `anyOf`, `oneOf`, and `prefixItems`. It also introduces comprehensive tests to ensure boolean schemas are handled correctly in both YAML and JSON formats, and adds a helper for resolving schemas. These changes address issue #278 and improve OpenAPI/JSON Schema compatibility.

### Schema structure improvements

* Updated the fields `all_of`, `any_of`, `one_of`, `prefix_items`, and `properties` in `ObjectSchema` to use `Schema` instead of `ObjectOrReference<ObjectSchema>`.
* Added a `Schema::resolve` method to facilitate resolving schemas, including handling boolean schemas by returning an empty `ObjectSchema`.

### Test coverage for boolean schemas

* Enhanced tests to verify correct parsing and serialization of boolean schemas in `properties`, `allOf`, `anyOf`, `oneOf`, and `prefixItems`, including round-trip checks for YAML and JSON.
* Updated existing tests to match the new structure, ensuring that references and inline schemas are correctly identified as `Schema` variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Boolean schemas now supported within `allOf`, `anyOf`, `oneOf`, `prefixItems`, and `properties` constructs.
  * Added new `resolve()` method for schema resolution functionality.

* **Tests**
  * Added comprehensive unit tests covering boolean schema parsing, serialization, and round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->