### PR TITLE
feat(oas3): add `jsonSchemaDialect` to Spec and `$schema` to ObjectSchema

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+{
+	"name": "Existing Docker Compose (Extend)",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../compose.dev.yaml",
+		"docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "dev",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,14 @@
 
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
-	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"rust-lang.rust-analyzer"
+			]
+		}
+	}
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  # Update this to the name of the service you want to work with in your docker-compose.yml file
+  dev:
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
+    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+    # array). The sample below assumes your primary file is in the root of your project.
+    #
+    # build:
+    #   context: .
+    #   dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      # Update this to wherever you want VS Code to mount the folder of your project
+      - ..:/workspaces:cached
+
+    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+    # cap_add:
+    #   - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+ 

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -1,0 +1,3 @@
+FROM docker.io/rust:latest
+
+RUN rustup component add rustfmt

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,0 +1,7 @@
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Containerfile.dev
+  
+  

--- a/crates/oas3/CHANGELOG.md
+++ b/crates/oas3/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add `jsonSchemaDialect` to `Spec` and `$schema` to `ObjectSchema`.
+  - `Spec::schema_dialect()` returns the effective dialect, falling back to the OAS 3.1 default.
+  - `ObjectSchema::effective_schema(&Spec)` resolves per-schema `$schema` → `jsonSchemaDialect` → OAS default.
+
 ## 0.22.0
 
 - Support boolean schemas in schema-bearing fields including `spec::Components::schemas`,

--- a/crates/oas3/src/lib.rs
+++ b/crates/oas3/src/lib.rs
@@ -242,4 +242,69 @@ components:
             from_reader(yaml.as_bytes()).unwrap()
         );
     }
+
+        #[test]
+    fn json_schema_dialect_parses_when_present() {
+        let spec = from_yaml(indoc::indoc! {"
+            openapi: 3.1.1
+            info:
+              title: Test
+              version: 1.0.0
+            jsonSchemaDialect: https://example.com/my-dialect
+        "})
+        .unwrap();
+
+        assert_eq!(
+            spec.json_schema_dialect.as_deref(),
+            Some("https://example.com/my-dialect")
+        );
+        assert_eq!(spec.schema_dialect(), "https://example.com/my-dialect");
+    }
+
+    #[test]
+    fn json_schema_dialect_is_none_when_absent() {
+        let spec = from_yaml(indoc::indoc! {"
+            openapi: 3.1.1
+            info:
+              title: Test
+              version: 1.0.0
+        "})
+        .unwrap();
+
+        assert_eq!(spec.json_schema_dialect, None);
+    }
+
+    #[test]
+    fn schema_dialect_returns_default_when_absent() {
+        let spec = from_yaml(indoc::indoc! {"
+            openapi: 3.1.1
+            info:
+              title: Test
+              version: 1.0.0
+        "})
+        .unwrap();
+
+        assert_eq!(
+            spec.schema_dialect(),
+            spec::OAS_DIALECT_ID
+        );
+    }
+
+    #[test]
+    fn json_schema_dialect_json_round_trip() {
+        let json = serde_json::json!({
+            "openapi": "3.1.1",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0"
+            },
+            "jsonSchemaDialect": "https://example.com/my-dialect"
+        });
+
+        let spec: OpenApiV3Spec =
+            serde_json::from_value(json.clone()).expect("should parse JSON");
+        let output = serde_json::to_value(&spec).expect("should serialize to JSON");
+
+        assert_eq!(output["jsonSchemaDialect"], json["jsonSchemaDialect"]);
+    }
 }

--- a/crates/oas3/src/lib.rs
+++ b/crates/oas3/src/lib.rs
@@ -243,7 +243,7 @@ components:
         );
     }
 
-        #[test]
+    #[test]
     fn json_schema_dialect_parses_when_present() {
         let spec = from_yaml(indoc::indoc! {"
             openapi: 3.1.1
@@ -284,10 +284,7 @@ components:
         "})
         .unwrap();
 
-        assert_eq!(
-            spec.schema_dialect(),
-            spec::OAS_DIALECT_ID
-        );
+        assert_eq!(spec.schema_dialect(), spec::OAS_DIALECT_ID);
     }
 
     #[test]
@@ -301,8 +298,7 @@ components:
             "jsonSchemaDialect": "https://example.com/my-dialect"
         });
 
-        let spec: OpenApiV3Spec =
-            serde_json::from_value(json.clone()).expect("should parse JSON");
+        let spec: OpenApiV3Spec = serde_json::from_value(json.clone()).expect("should parse JSON");
         let output = serde_json::to_value(&spec).expect("should serialize to JSON");
 
         assert_eq!(output["jsonSchemaDialect"], json["jsonSchemaDialect"]);

--- a/crates/oas3/src/spec/mod.rs
+++ b/crates/oas3/src/spec/mod.rs
@@ -256,7 +256,6 @@ impl Spec {
     }
 }
 
-
 /// The default OAS 3.1 JSON Schema dialect URI, used when `jsonSchemaDialect` is not set.
 ///
 /// See <https://spec.openapis.org/oas/v3.1.1#fixed-fields>.

--- a/crates/oas3/src/spec/mod.rs
+++ b/crates/oas3/src/spec/mod.rs
@@ -157,6 +157,16 @@ pub struct Spec {
     /// See <https://spec.openapis.org/oas/v3.1.1#specification-extensions>.
     #[serde(flatten, with = "spec_extensions")]
     pub extensions: Map<String, serde_json::Value>,
+
+    /// The default value for the `$schema` keyword within Schema Objects contained within this
+    /// OAS document. This MUST be in the form of a URI.
+    ///
+    /// If this field is absent, the default value is the OAS dialect schema id:
+    /// [`OAS_DIALECT_ID`].
+    ///
+    /// See <https://spec.openapis.org/oas/v3.1.1#fixed-fields>.
+    #[serde(rename = "jsonSchemaDialect", skip_serializing_if = "Option::is_none")]
+    pub json_schema_dialect: Option<String>,
 }
 
 impl Spec {
@@ -235,4 +245,19 @@ impl Spec {
     pub fn primary_server(&self) -> Option<&Server> {
         self.servers.first()
     }
+
+    /// Returns the effective JSON Schema dialect for this spec.
+    ///
+    /// Falls back to [`OAS_DIALECT_ID`] when `jsonSchemaDialect` is not set.
+    pub fn schema_dialect(&self) -> &str {
+        self.json_schema_dialect
+            .as_deref()
+            .unwrap_or(OAS_DIALECT_ID)
+    }
 }
+
+
+/// The default OAS 3.1 JSON Schema dialect URI, used when `jsonSchemaDialect` is not set.
+///
+/// See <https://spec.openapis.org/oas/v3.1.1#fixed-fields>.
+pub const OAS_DIALECT_ID: &str = "https://spec.openapis.org/oas/3.1/dialect/base";

--- a/crates/oas3/src/spec/schema.rs
+++ b/crates/oas3/src/spec/schema.rs
@@ -115,7 +115,6 @@ pub struct ObjectSchema {
     // Keywords for Applying Subschemas With Logic
     // https://json-schema.org/draft/2020-12/json-schema-core#name-keywords-for-applying-subsch
     // #########################################################################
-
     /// The `$schema` keyword may be present in any Schema Object that is a schema resource root,
     /// and if present MUST be used to determine which dialect should be used when processing
     /// the schema. Overrides `jsonSchemaDialect` from the OpenAPI Object.
@@ -1088,9 +1087,6 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(
-            schema.effective_schema(&spec),
-            super::super::OAS_DIALECT_ID
-        );
+        assert_eq!(schema.effective_schema(&spec), super::super::OAS_DIALECT_ID);
     }
 }

--- a/crates/oas3/src/spec/schema.rs
+++ b/crates/oas3/src/spec/schema.rs
@@ -574,8 +574,7 @@ impl ObjectSchema {
     pub fn effective_schema<'s>(&'s self, spec: &'s Spec) -> &'s str {
         self.schema
             .as_deref()
-            .or(spec.json_schema_dialect.as_deref())
-            .unwrap_or(super::OAS_DIALECT_ID)
+            .unwrap_or_else(|| spec.schema_dialect())
     }
 }
 

--- a/crates/oas3/src/spec/schema.rs
+++ b/crates/oas3/src/spec/schema.rs
@@ -116,6 +116,14 @@ pub struct ObjectSchema {
     // https://json-schema.org/draft/2020-12/json-schema-core#name-keywords-for-applying-subsch
     // #########################################################################
 
+    /// The `$schema` keyword may be present in any Schema Object that is a schema resource root,
+    /// and if present MUST be used to determine which dialect should be used when processing
+    /// the schema. Overrides `jsonSchemaDialect` from the OpenAPI Object.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.1.1#specifying-schema-dialects>.
+    #[serde(rename = "$schema", skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+
     //
     /// An instance validates successfully against this keyword if it validates successfully against
     /// all schemas defined by this keyword's value.
@@ -558,6 +566,17 @@ impl ObjectSchema {
             TypeSet::Multiple(set) => set.contains(&Type::Null),
         })
     }
+
+    /// Returns the effective JSON Schema dialect for this schema.
+    ///
+    /// Resolution order: `$schema` on this object → `jsonSchemaDialect` on the spec →
+    /// [`super::OAS_DIALECT_ID`].
+    pub fn effective_schema<'s>(&'s self, spec: &'s Spec) -> &'s str {
+        self.schema
+            .as_deref()
+            .or(spec.json_schema_dialect.as_deref())
+            .unwrap_or(super::OAS_DIALECT_ID)
+    }
 }
 
 /// A boolean JSON schema.
@@ -967,5 +986,112 @@ mod tests {
         let schema2: ObjectSchema =
             serde_json::from_str(&json_output).expect("should parse JSON again");
         assert_eq!(schema, schema2);
+    }
+
+    #[test]
+    fn schema_keyword_parses_when_present() {
+        let spec = indoc::indoc! {r#"
+            $schema: https://example.com/custom-dialect
+            type: string
+        "#};
+        let schema = yaml_serde::from_str::<ObjectSchema>(spec).unwrap();
+
+        assert_eq!(
+            schema.schema.as_deref(),
+            Some("https://example.com/custom-dialect")
+        );
+        assert_eq!(schema.schema_type, Some(TypeSet::Single(Type::String)));
+    }
+
+    #[test]
+    fn schema_keyword_is_none_when_absent() {
+        let spec = indoc::indoc! {"
+            type: string
+        "};
+        let schema = yaml_serde::from_str::<ObjectSchema>(spec).unwrap();
+
+        assert_eq!(schema.schema, None);
+        assert_eq!(schema.schema_type, Some(TypeSet::Single(Type::String)));
+    }
+
+    #[test]
+    fn schema_keyword_round_trip() {
+        let spec = indoc::indoc! {r#"
+            $schema: https://spec.openapis.org/oas/3.1/dialect/base
+            properties:
+              name:
+                type: string
+            type: object
+        "#};
+
+        let original = yaml_serde::from_str::<ObjectSchema>(spec).unwrap();
+        let serialized = yaml_serde::to_string(&original).unwrap();
+
+        pretty_assertions::assert_eq!(spec, serialized);
+    }
+
+    #[test]
+    fn effective_schema_uses_own_schema_first() {
+        let spec = crate::from_yaml(indoc::indoc! {"
+            openapi: 3.1.1
+            info:
+              title: Test
+              version: 1.0.0
+            jsonSchemaDialect: https://example.com/spec-dialect
+        "})
+        .unwrap();
+
+        let schema = ObjectSchema {
+            schema: Some("https://example.com/own-dialect".into()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            schema.effective_schema(&spec),
+            "https://example.com/own-dialect"
+        );
+    }
+
+    #[test]
+    fn effective_schema_falls_back_to_spec_dialect() {
+        let spec = crate::from_yaml(indoc::indoc! {"
+            openapi: 3.1.1
+            info:
+              title: Test
+              version: 1.0.0
+            jsonSchemaDialect: https://example.com/spec-dialect
+        "})
+        .unwrap();
+
+        let schema = ObjectSchema {
+            schema: None,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            schema.effective_schema(&spec),
+            "https://example.com/spec-dialect"
+        );
+    }
+
+    #[test]
+    fn effective_schema_falls_back_to_oas_default() {
+        let spec = crate::from_yaml(indoc::indoc! {"
+            openapi: 3.1.1
+            info:
+              title: Test
+              version: 1.0.0
+        "})
+        .unwrap();
+
+        let schema = ObjectSchema {
+            schema: None,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            schema.effective_schema(&spec),
+            super::super::OAS_DIALECT_ID
+        );
     }
 }


### PR DESCRIPTION
Closes #160.

Adds the `jsonSchemaDialect` fixed field to the OpenAPI Object (`Spec`) and
the `$schema` keyword to `ObjectSchema`, along with helper methods for
resolving the effective JSON Schema dialect.

- Add `json_schema_dialect: Option<String>` field
- Add `OAS_DIALECT_ID` constant (`https://spec.openapis.org/oas/3.1/dialect/base`)
- Add `schema_dialect()` method — returns the custom value when set, falls
  back to `OAS_DIALECT_ID` when absent
- Add `schema: Option<String>` field (serde `$schema`) — per-schema dialect
  override that takes precedence over `jsonSchemaDialect`
- Add `effective_schema(&Spec)` method — resolves the dialect chain:
  `$schema` → `jsonSchemaDialect` → `OAS_DIALECT_ID`

Added tests in order to assure proper usage of the library.

## Deferred

Dialect-aware validation of schema keywords, as per inquired in the issue, is not included. The struct currently only models Draft 2020-12 keywords, and validating against other dialects would require an immense change to the library's code. I propose that this should be tracked in a different issue.

In the meantime, downstream code can now determine which schema rules to apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAPI/JSON Schema dialect settings in schema documents, including per-schema `$schema` values and a document-level default.
  * Schema dialect resolution now follows a clear fallback order, improving how schema metadata is interpreted.
* **Bug Fixes**
  * Improved round-trip handling so schema dialect information is preserved when reading and writing supported documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->