### PR TITLE
Add Nix Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: monthly
+  - package-ecosystem: nix
+    directory: /
+    schedule:
+      interval: monthly
   - package-ecosystem: cargo
     directory: /
     schedule:


### PR DESCRIPTION
## Summary

- enable Dependabot's native Nix flake ecosystem at the repository root
- check `flake.lock` monthly for newer Git-backed input revisions
- allow automated updates to the pinned `x52dev/nix` tooling alongside the other flake inputs

## Impact

Dependabot will open focused pull requests when upstream flake inputs have newer commits. Inputs remain immutable between updates because builds continue to use the committed `flake.lock`.

## Validation

- repository formatter completed without additional changes
- `nix develop -c just check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added monthly automated update checks for Nix packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->