### PR TITLE
chore: use shared Rust Just MSRV recipes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,17 @@ jobs:
         with:
           tool: just,nextest
 
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+        with:
+          extra-conf: lazy-trees = true
+
+      - name: Set up FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+
+      - name: Enter Nix devshell
+        uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+
       - name: Work around MSRV issues
         if: matrix.toolchain.name == 'msrv'
         run: just downgrade-for-msrv

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,6 +27,17 @@ jobs:
         with:
           tool: just,cargo-llvm-cov
 
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+        with:
+          extra-conf: lazy-trees = true
+
+      - name: Set up FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+
+      - name: Enter Nix devshell
+        uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+
       - name: Generate code coverage
         run: just test-coverage-codecov
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,17 @@ jobs:
         with:
           tool: just,cargo-hack
 
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+        with:
+          extra-conf: lazy-trees = true
+
+      - name: Set up FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+
+      - name: Enter Nix devshell
+        uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+
       - name: Check with Clippy
         run: just clippy
 
@@ -74,6 +85,17 @@ jobs:
         uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
         with:
           tool: just
+
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+        with:
+          extra-conf: lazy-trees = true
+
+      - name: Set up FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+
+      - name: Enter Nix devshell
+        uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
 
       - name: Read external types Rust toolchain
         id: toolchain

--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784633661,
-        "narHash": "sha256-eOrF1y0svdniEnjIuuvkzOv6z/ltBepYjApINcDY1Xg=",
+        "lastModified": 1785501466,
+        "narHash": "sha256-EmBn1w7+V9l1P4XqFLSZDVOxMtMIIGxUrJawlrvaO5U=",
         "owner": "x52dev",
         "repo": "nix",
-        "rev": "5e898b3d4b5bb9801964488d6ab4a6ed445c1809",
+        "rev": "7f726782d3870c1d11a9480ebeb9a34a693d4a17",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,8 @@
 
   outputs = inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [ inputs.x52.flakeModules.default ];
+
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       perSystem = { pkgs, config, inputs', system, lib, ... }: {
         formatter = pkgs.nixpkgs-fmt;
@@ -20,14 +22,17 @@
             config.formatter
             inputs'.x52.packages.x52-release-tools
             pkgs.cargo-rdme
+            pkgs.jq
             pkgs.just
             pkgs.libgit2
-            pkgs.nodePackages.prettier
+            pkgs.prettier
             pkgs.taplo
             pkgs.watchexec
           ] ++ lib.optional pkgs.stdenv.isDarwin [
             pkgs.pkgsBuildHost.libiconv
           ];
+
+          shellHook = config.x52.justRust.shellHook;
         };
       };
     };

--- a/justfile
+++ b/justfile
@@ -1,15 +1,10 @@
+import '.toolchain/rust.just'
+
 _list:
     @just --list
 
 toolchain := ""
 external_types_toolchain := "nightly-2026-03-20"
-msrv := ```
-    cargo metadata --format-version=1 \
-    | jq -r 'first(.packages[] | select(.source == null and .rust_version)) | .rust_version' \
-    | sed -E 's/^1\.([0-9]{2})$/1\.\1\.0/'
-```
-msrv_rustup := "+" + msrv
-
 # Check project.
 [group("lint")]
 check: && clippy


### PR DESCRIPTION
## Summary

- import the shared Rust Just flake-parts module
- replace the local MSRV definitions with `.toolchain/rust.just`
- retain the project-selected `pkgs.just` and add explicit `jq` support for the shared recipe
- replace the removed `pkgs.nodePackages.prettier` with `pkgs.prettier`

## Why

The shared recipe selects the lowest declared MSRV across workspace members and fails clearly when the workspace metadata is incomplete. This replaces the local first-package variant while preserving the current evaluated MSRV.

## Validation

- `nix develop -c just --list`
- verified `.toolchain/rust.just` is a symlink
- evaluated the existing MSRV through the shared recipe
- `nix flake check --no-build`
- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/*.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated validation workflows for more consistent testing, coverage reporting, and linting.
  * Improved development environment setup and caching to make local and CI checks more reliable.
  * Added JSON tooling and streamlined formatting support.
  * Centralized Rust toolchain task configuration for consistent development commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->