### PR TITLE
ci: simplify Nix setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,16 +45,13 @@ jobs:
         with:
           tool: just,nextest
 
-      - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Enter Nix devshell
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci
 
       - name: Work around MSRV issues
         if: matrix.toolchain.name == 'msrv'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,16 +27,13 @@ jobs:
         with:
           tool: just,cargo-llvm-cov
 
-      - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Enter Nix devshell
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci
 
       - name: Generate code coverage
         run: just test-coverage-codecov

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,16 +32,13 @@ jobs:
         with:
           tool: just,cargo-hack
 
-      - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Enter Nix devshell
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci
 
       - name: Check with Clippy
         run: just clippy
@@ -86,16 +83,13 @@ jobs:
         with:
           tool: just
 
-      - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Enter Nix devshell
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci
 
       - name: Read external types Rust toolchain
         id: toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,19 +33,15 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         id: release-plz
 
-      - name: Install Determinate Nix
+      - name: Install Nix
         if: ${{ steps.release-plz.outputs.prs_created == 'true' || steps.release-plz.outputs.releases_created == 'true' }}
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        if: ${{ steps.release-plz.outputs.prs_created == 'true' || steps.release-plz.outputs.releases_created == 'true' }}
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Enter Nix devshell
         if: ${{ steps.release-plz.outputs.prs_created == 'true' || steps.release-plz.outputs.releases_created == 'true' }}
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci-release
 
       - name: Bump changelog versions
         if: ${{ steps.release-plz.outputs.prs_created == 'true' }}

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,14 @@
       perSystem = { pkgs, config, inputs', system, lib, ... }: {
         formatter = pkgs.nixpkgs-fmt;
 
+        devShells.ci = pkgs.mkShell {
+          shellHook = config.x52.justRust.shellHook;
+        };
+
+        devShells.ci-release = pkgs.mkShell {
+          packages = [ inputs'.x52.packages.x52-release-tools ];
+        };
+
         devShells.default = pkgs.mkShell {
           packages = [
             config.formatter


### PR DESCRIPTION
## Summary

- install Nix with `nix-quick-install-action`
- remove the FlakeHub cache from CI, lint, coverage, and release
- keep `nix-develop` separate
- use a focused `.#ci` shell for test/lint/coverage and `.#ci-release` for release tooling
- keep the full default development shell unchanged

## Why

The latest Blacksmith-provided baseline for the existing setup showed the release job spending 5m02s in the FlakeHub cache post-step. That release job took 7m37s overall, while the actual changelog operation took 2s. The setup path also took 27s for Determinate Nix, 12s for cache setup, and 30s to enter the full shell.

The focused shells retain only the capabilities each workflow needs: the shared Just shell hook for CI and the x52 release tools for release.

## Validation

- `nix develop .#ci -c just --list`
- `nix develop .#ci-release -c command -v x52-bump-changelogs`
- `nix develop .#ci-release -c command -v x52-update-release-notes`
- `nix flake check --no-build --all-systems`

The release workflow runs only after pushes to `main`; the PR CI and lint workflows validate the quick installer path directly.
